### PR TITLE
make image string nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -250,6 +250,7 @@ components:
             example: Alkohol und alkoholische Getränke
           image: 
             type: string
+            nullable: true
             example: https://www.bundesfinanzministerium.de/Content/DE/Apps/Items/Images/alkohol.jpg?__blob=normal&v=4
           alttext: 
             type: string


### PR DESCRIPTION
Image paths are not always populated which can cause problems in generated apis.

Adding nullable: true allows fields to be null which for image is true:

Example: 4th result of this query has image null 

https://www.bundesfinanzministerium.de/SiteGlobals/Functions/Apps/retrieve/kategorien?client=ZUP&view=renderJson[App]

![image](https://user-images.githubusercontent.com/2640499/134295810-17d7541f-1dd4-4148-bf53-481ed5ffea95.png)
